### PR TITLE
feat: s3 access log remediation TF reference

### DIFF
--- a/config_rules/s3_access_logs/remediate/README.md
+++ b/config_rules/s3_access_logs/remediate/README.md
@@ -34,7 +34,19 @@ resource "aws_config_remediation_configuration" "this" {
   }
   parameter {
     name           = "TargetBucket"
-    resource_value = "log-archive-satellite-${var.account_id}"
+    static_value   = "log-archive-satellite-${var.account_id}"
+  }
+  parameter {
+    name           = "GrantedPermission"
+    static_value   = "FULL_CONTROL"
+  }
+  parameter {
+    name           = "GranteeType"
+    static_value   = "Group"
+  }
+  parameter {
+    name           = "GranteeUri"
+    static_value   = "http://acs.amazonaws.com/groups/s3/LogDelivery"
   }
   parameter {
     name         = "SSEAlgorithm"


### PR DESCRIPTION
Remediation lambda not required since a AWS managed remediation rule exists. TF reference provided instead as a placeholder.