### PR TITLE
feat: consistent resource names for AWS nuke exclude

### DIFF
--- a/bootstrap/satellite_account_iam/main.tf
+++ b/bootstrap/satellite_account_iam/main.tf
@@ -1,3 +1,9 @@
+data "aws_caller_identity" "current" {}
+
+locals {
+  account_id = data.aws_caller_identity.current.account_id
+}
+
 # Assume role policy for the central cbs account to manage config rules via Terraform
 resource "aws_iam_role" "config_terraform_role" {
   name               = "ConfigTerraformAdminExecutionRole"
@@ -41,7 +47,7 @@ data "aws_iam_policy_document" "config_terraform_policy" {
     actions = [
       "dynamodb:*",
     ]
-    resources = ["arn:aws:dynamodb:${var.region}:${var.account_id}:table/tfstate-lock"]
+    resources = ["arn:aws:dynamodb:${var.region}:${local.account_id}:table/tfstate-lock"]
   }
 
   statement {

--- a/bootstrap/satellite_account_iam/variables.tf
+++ b/bootstrap/satellite_account_iam/variables.tf
@@ -1,8 +1,3 @@
-variable "account_id" {
-  description = "(Required) The account ID to perform actions on."
-  type        = string
-}
-
 variable "central_account_id" {
   description = "(Required) The account ID to centrally manage all accounts."
   type        = string

--- a/terragrunt/aws/cloudtrail/cloudtrail.tf
+++ b/terragrunt/aws/cloudtrail/cloudtrail.tf
@@ -1,6 +1,7 @@
 locals {
   satellite_bucket_arn = "arn:aws:s3:::${var.satellite_bucket_name}"
   trail_prefix         = "cloudtrail_logs"
+  trail_arn            = "arn:aws:cloudtrail:${var.region}:${var.account_id}:trail/CbsSatelliteTrail"
 }
 
 #
@@ -18,6 +19,10 @@ resource "aws_cloudtrail" "satellite_trail" {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
   }
+
+  depends_on = [
+    aws_s3_bucket_policy.satellite_trail
+  ]
 }
 
 #
@@ -61,7 +66,7 @@ data "aws_iam_policy_document" "satellite_trail" {
     condition {
       test     = "StringEquals"
       variable = "aws:SourceArn"
-      values   = [aws_cloudtrail.satellite_trail.arn]
+      values   = [local.trail_arn]
     }
   }
 }

--- a/terragrunt/aws/config/iam.tf
+++ b/terragrunt/aws/config/iam.tf
@@ -1,11 +1,10 @@
 resource "aws_iam_role" "security_config" {
-  name = "security_config"
-
+  name = "CbsConfigPolicy"
   assume_role_policy = data.aws_iam_policy_document.aws_config_assume_role_policy.json
 }
 
 resource "aws_iam_policy_attachment" "managed_policy" {
-  name = "aws_config_managed_policy"
+  name = "CbsConfigManagedPolicy"
   roles = [
     aws_iam_role.security_config.name,
     aws_iam_role.cbs_s3_satellite_bucket_rule.name
@@ -14,12 +13,12 @@ resource "aws_iam_policy_attachment" "managed_policy" {
 }
 
 resource "aws_iam_policy" "aws_config_policy" {
-  name   = "aws_config_policy"
+  name   = "CbsConfigPolicy"
   policy = data.aws_iam_policy_document.aws_config_policy.json
 }
 
 resource "aws_iam_policy_attachment" "aws-aws_config_policy-policy" {
-  name       = "aws_config_policy"
+  name       = "CbsConfigPolicy"
   roles      = ["${aws_iam_role.security_config.name}"]
   policy_arn = aws_iam_policy.aws_config_policy.arn
 }

--- a/terragrunt/aws/config/s3_satellite_bucket.tf
+++ b/terragrunt/aws/config/s3_satellite_bucket.tf
@@ -36,7 +36,7 @@ data "archive_file" "cbs_s3_satellite_bucket_rule" {
 
 resource "aws_lambda_function" "cbs_s3_satellite_bucket_rule" {
   filename      = "/tmp/cbs_s3_satellite_bucket_rule.zip"
-  function_name = "cbs_s3_satellite_bucket_rule"
+  function_name = "CbsS3SatelliteBucketRule"
   role          = aws_iam_role.cbs_s3_satellite_bucket_rule.arn
   handler       = "s3_satellite_bucket_rule.lambda_handler"
 
@@ -74,7 +74,7 @@ resource "aws_cloudwatch_log_group" "cbs_s3_satellite_bucket_rule" {
 # Lambda execution role
 #
 resource "aws_iam_role" "cbs_s3_satellite_bucket_rule" {
-  name               = "cbs_s3_satellite_bucket_rule"
+  name               = "CbsS3SatelliteBucketRule"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
 
   tags = {
@@ -94,7 +94,7 @@ resource "aws_iam_role_policy_attachment" "cbs_s3_satellite_bucket_rule_s3_list_
 }
 
 resource "aws_iam_policy" "s3_list_buckets" {
-  name        = "s3_list_buckets"
+  name        = "CbsS3ListBuckets"
   path        = "/"
   description = "IAM policy for listing all S3 buckets"
   policy      = data.aws_iam_policy_document.s3_list_buckets.json


### PR DESCRIPTION
# Summary
1. Update the resource names to make them easier to exclude in our AWS nuke config that runs weekly against scratch accounts.
2. Fix CloudTrail creation by making it depend on S3 bucket policy.
3. Update satellite bootstrap to get AWS account ID from the `aws_caller_identity` data element.

# Related
* #9 