### PR TITLE
fix: change to `satellite_accounts` without .json

### DIFF
--- a/.github/workflows/retrieve-accounts.yml
+++ b/.github/workflows/retrieve-accounts.yml
@@ -22,5 +22,5 @@ jobs:
       - name: Read account file
         id: set-matrix
         run: |
-          accounts=$(jq -n -c "{\"include\": [inputs | {"account": .} ] }"  satellite_accounts.json)
+          accounts=$(jq -n -c "{\"include\": [inputs | {"account": .} ] }"  satellite_accounts)
           echo "::set-output name=matrix::$accounts"

--- a/bootstrap/satellite_account_iam/bootstrap.sh
+++ b/bootstrap/satellite_account_iam/bootstrap.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+#
+# Bootstraps a given satellite account's IAM roles.
+# This is based on the AWS access key and secret that
+# is currently exported. 
+#
+
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+
+rm -rf "$SCRIPT_DIR"/terraform* "$SCRIPT_DIR"/.terraform*
+terraform -chdir="$SCRIPT_DIR" init
+terraform -chdir="$SCRIPT_DIR" apply


### PR DESCRIPTION
# Summary
The `satellite_accounts` file should not have a `.json` file extension.
Once this common workflow is merged to main, we can update
the rest of the project files to reference the file without `.json`.

# ⚠️  Note
Once this is merged, it will break all workflows until the other references
to `satellite_accounts.json` are fixed.