### PR TITLE
feat: switch back to custom lambda config rule for s3 access logs

### DIFF
--- a/terragrunt/aws/config/config_rules/s3_access_logs/README.md
+++ b/terragrunt/aws/config/config_rules/s3_access_logs/README.md
@@ -1,0 +1,14 @@
+### AWS permissions required
+Compliance check retrieves the replication configuration of a s3 bucket to check if it's replicating to the satellite bucket with name `cbs-satellite-account-bucket${AWS_ACCOUNT_ID}`.
+```json
+{
+  "Effect": "Allow",
+  "Action": "s3:GetReplicationConfiguration",
+  "Resource": "arn:aws:s3:::*"
+},
+{
+  "Effect": "Allow",
+  "Action": "s3:ListAllMyBuckets",
+  "Resource": "arn:aws:s3:::*"
+}
+```

--- a/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule.py
+++ b/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule.py
@@ -164,25 +164,26 @@ def evaluate_compliance(configuration_item, event):
     evaluations = []
 
     for bucket in buckets_list["Buckets"]:
-      current_item = copy(configuration_item)
-      current_item["resourceId"] = bucket["Name"]
+        current_item = copy(configuration_item)
+        current_item["resourceId"] = bucket["Name"]
 
-      if bucket["Name"] == logging_bucket_name:
-        evaluations.append(build_evaluation(current_item, "NOT_APPLICABLE"))
-        continue
+        if bucket["Name"] == logging_bucket_name:
+            evaluations.append(build_evaluation(current_item, "NOT_APPLICABLE"))
+            continue
 
-      response = s3.get_bucket_logging(Bucket=bucket["Name"])
-      if "LoggingEnabled" in response:
-          if response["LoggingEnabled"]["TargetBucket"] == logging_bucket_name:
-              evaluations.append(build_evaluation(current_item, "COMPLIANT"))
-              continue
-              
+        response = s3.get_bucket_logging(Bucket=bucket["Name"])
+        if "LoggingEnabled" in response:
+            if response["LoggingEnabled"]["TargetBucket"] == logging_bucket_name:
+                evaluations.append(build_evaluation(current_item, "COMPLIANT"))
+                continue
 
-      evaluations.append(build_evaluation(
-          current_item,
-          "NON_COMPLIANT",
-          f'The "{bucket["Name"]}" bucket is not logging to {logging_bucket_name}',
-      ))
+        evaluations.append(
+            build_evaluation(
+                current_item,
+                "NON_COMPLIANT",
+                f'The "{bucket["Name"]}" bucket is not logging to {logging_bucket_name}',
+            )
+        )
 
     return evaluations
 

--- a/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule.py
+++ b/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule.py
@@ -1,0 +1,203 @@
+import boto3
+import botocore
+import datetime
+import json
+
+from copy import copy
+
+# Set to True to get the lambda to assume the Role attached on the Config Service (cross-account).
+ASSUME_ROLE_MODE = False
+DEFAULT_RESOURCE_TYPE = "AWS::S3::Bucket"
+
+
+def lambda_handler(event, context):
+    "Lambda handler that invokes the compliance evaluation"
+    global AWS_CONFIG_CLIENT
+
+    check_defined(event, "event")
+    invoking_event = json.loads(event["invokingEvent"])
+
+    AWS_CONFIG_CLIENT = get_client("config", event)
+    configuration_item = get_configuration_item(invoking_event)
+    evaluation = evaluate_compliance(configuration_item, event)
+
+    AWS_CONFIG_CLIENT.put_evaluations(
+        Evaluations=evaluation, ResultToken=event["resultToken"]
+    )
+
+    # Used for unit tests
+    return evaluation
+
+
+def get_client(service, event):
+    """Return the service boto client. It should be used instead of directly calling the client.
+    Keyword arguments:
+    service - the service name used for calling the boto.client()
+    event - the event variable given in the lambda handler
+    """
+    if not ASSUME_ROLE_MODE:
+        return boto3.client(service)
+    credentials = get_assume_role_credentials(event["executionRoleArn"])
+    return boto3.client(
+        service,
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+
+def check_defined(reference, reference_name):
+    "Check that a given object is defined"
+    if not reference:
+        raise Exception("Error: ", reference_name, "is not defined")
+    return reference
+
+
+def is_oversized_changed_notification(message_type):
+    "Check whether the message is OversizedConfigurationItemChangeNotification or not"
+    check_defined(message_type, "messageType")
+    return message_type == "OversizedConfigurationItemChangeNotification"
+
+
+def is_scheduled_notification(message_type):
+    "Check whether the message is a ScheduledNotification or not"
+    check_defined(message_type, "messageType")
+    return message_type == "ScheduledNotification"
+
+
+def get_configuration(resource_type, resource_id, configuration_capture_time):
+    """Get configurationItem using getResourceConfigHistory API
+    in case of OversizedConfigurationItemChangeNotification
+    """
+    result = AWS_CONFIG_CLIENT.get_resource_config_history(
+        resourceType=resource_type,
+        resourceId=resource_id,
+        laterTime=configuration_capture_time,
+        limit=1,
+    )
+    configurationItem = result["configurationItems"][0]
+    return convert_api_configuration(configurationItem)
+
+
+def convert_api_configuration(configurationItem):
+    "Convert from the API model to the original invocation model"
+    for k, v in configurationItem.items():
+        if isinstance(v, datetime.datetime):
+            configurationItem[k] = str(v)
+    configurationItem["awsAccountId"] = configurationItem["accountId"]
+    configurationItem["ARN"] = configurationItem["arn"]
+    configurationItem["configurationStateMd5Hash"] = configurationItem[
+        "configurationItemMD5Hash"
+    ]
+    configurationItem["configurationItemVersion"] = configurationItem["version"]
+    configurationItem["configuration"] = json.loads(configurationItem["configuration"])
+    if "relationships" in configurationItem:
+        for i in range(len(configurationItem["relationships"])):
+            configurationItem["relationships"][i]["name"] = configurationItem[
+                "relationships"
+            ][i]["relationshipName"]
+    return configurationItem
+
+
+def get_configuration_item(invokingEvent):
+    """Get the configuration item that will be used to determine
+    compliance for the evaluation.
+    """
+    check_defined(invokingEvent, "invokingEvent")
+
+    # Use the getResourceConfigHistory API to get the config item
+    if is_oversized_changed_notification(invokingEvent["messageType"]):
+        configurationItemSummary = check_defined(
+            invokingEvent["configurationItemSummary"], "configurationItemSummary"
+        )
+        return get_configuration(
+            configurationItemSummary["resourceType"],
+            configurationItemSummary["resourceId"],
+            configurationItemSummary["configurationItemCaptureTime"],
+        )
+
+    # Create a generic placeholder for scheduled runs
+    elif is_scheduled_notification(invokingEvent["messageType"]):
+        return {
+            "resourceType": DEFAULT_RESOURCE_TYPE,
+            "resourceId": invokingEvent["awsAccountId"],
+            "configurationItemStatus": "OK",
+            "configurationItemCaptureTime": str(
+                invokingEvent["notificationCreationTime"]
+            ),
+        }
+
+    # Default to using the config item from the event
+    return check_defined(invokingEvent["configurationItem"], "configurationItem")
+
+
+def get_assume_role_credentials(role_arn):
+    "Get the assumed role credentials used for cross-account invocations"
+    sts_client = boto3.client("sts")
+    try:
+        assume_role_response = sts_client.assume_role(
+            RoleArn=role_arn, RoleSessionName="configLambdaExecution"
+        )
+        return assume_role_response["Credentials"]
+    except botocore.exceptions.ClientError as ex:
+        # Scrub error message for any internal account info leaks
+        if "AccessDenied" in ex.response["Error"]["Code"]:
+            ex.response["Error"][
+                "Message"
+            ] = "AWS Config does not have permission to assume the IAM role."
+        else:
+            ex.response["Error"]["Message"] = "InternalError"
+            ex.response["Error"]["Code"] = "InternalError"
+        raise ex
+
+
+def evaluate_compliance(configuration_item, event):
+    "Check if the s3 logging has been enabled"
+    check_defined(configuration_item, "configuration_item")
+
+    rule_parameters = json.loads(event["ruleParameters"])
+    logging_bucket_name = rule_parameters["targetBucket"]
+
+    s3 = get_client("s3", event)
+    buckets_list = s3.list_buckets()
+
+    evaluations = []
+
+    for bucket in buckets_list["Buckets"]:
+      current_item = copy(configuration_item)
+      current_item["resourceId"] = bucket["Name"]
+
+      if bucket["Name"] == logging_bucket_name:
+        evaluations.append(build_evaluation(current_item, "NOT_APPLICABLE"))
+        continue
+
+      response = s3.get_bucket_logging(Bucket=bucket["Name"])
+      if "LoggingEnabled" in response:
+          if response["LoggingEnabled"]["TargetBucket"] == logging_bucket_name:
+              evaluations.append(build_evaluation(current_item, "COMPLIANT"))
+              continue
+              
+
+      evaluations.append(build_evaluation(
+          current_item,
+          "NON_COMPLIANT",
+          f'The "{bucket["Name"]}" bucket is not logging to {logging_bucket_name}',
+      ))
+
+    return evaluations
+
+
+def build_evaluation(configuration_item, compliance_type, annotation=None):
+    """Generate an evaluation object based on the config item and compliance:
+    configuration_item -- the configuration item being evaluated
+    compliance_type -- either COMPLIANT, NON_COMPLIANT or NOT_APPLICABLE
+    annotation -- an annotation to be added to the evaluation (default None)
+    """
+    eval_cc = {}
+    if annotation:
+        eval_cc["Annotation"] = annotation
+    eval_cc["ComplianceResourceType"] = configuration_item["resourceType"]
+    eval_cc["ComplianceResourceId"] = configuration_item["resourceId"]
+    eval_cc["ComplianceType"] = compliance_type
+    eval_cc["OrderingTimestamp"] = configuration_item["configurationItemCaptureTime"]
+    return eval_cc

--- a/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule_test.py
+++ b/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule_test.py
@@ -1,0 +1,149 @@
+import sys
+import unittest
+
+try:
+    from unittest.mock import MagicMock
+except ImportError:
+    from mock import MagicMock
+
+
+# Define the default resource to report to Config Rules
+DEFAULT_RESOURCE_TYPE = "AWS::S3::Bucket"
+
+CONFIG_CLIENT_MOCK = MagicMock()
+S3_CLIENT_MOCK = MagicMock()
+STS_CLIENT_MOCK = MagicMock()
+
+
+class Boto3Mock:
+    @staticmethod
+    def client(client_name, *args, **kwargs):
+        if client_name == "config":
+            return CONFIG_CLIENT_MOCK
+        if client_name == "sts":
+            return STS_CLIENT_MOCK
+        if client_name == "s3":
+            return S3_CLIENT_MOCK
+        raise Exception("Attempting to create an unknown client")
+
+
+sys.modules["boto3"] = Boto3Mock()
+
+RULE = __import__("s3_access_logs_rule")
+
+
+class ComplianceTest(unittest.TestCase):
+
+    invoking_event_bucket_config_change = '{"configurationItem":{"configurationItemStatus":"ResourceDiscovered","configurationItemCaptureTime":"2018-07-02T03:37:52.418Z","resourceType":"AWS::S3::Bucket","resourceId":"s3-ca-central-1","resourceName":"s3-ca-central-1"},"notificationCreationTime":"2018-07-02T23:05:34.445Z","messageType":"ConfigurationItemChangeNotification"}'
+    invoking_event_bucket_periodic_change = '{"awsAccountId":"123456789012","notificationCreationTime":"2016-07-13T21:50:00.373Z","messageType":"ScheduledNotification","recordVersion":"1.0"}'
+    rule_parameters = '{"targetBucket":"cbs-satellite-account-bucket123456789012"}'
+
+
+    def setUp(self):
+        pass
+
+    def test_non_compliant_config_change(self):
+        invoking_event = self.invoking_event_bucket_config_change
+        lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
+        s3_mock([],[{"Name": "random-bucket-123456789012"}])
+        response = RULE.lambda_handler(lambda_event, {})
+        resp_expected = build_expected_response(
+            "NON_COMPLIANT",
+            "random-bucket-123456789012",
+            annotation='The "random-bucket-123456789012" bucket is not logging to cbs-satellite-account-bucket123456789012',
+        )
+        assert_successful_evaluation(self, response[0], resp_expected)
+
+    def test_compliant_config_change(self):
+        invoking_event = self.invoking_event_bucket_config_change
+        lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
+        s3_mock("cbs-satellite-account-bucket123456789012", [{"Name": "random-bucket-123456789012"}])
+        response = RULE.lambda_handler(lambda_event, {})
+        resp_expected = build_expected_response("COMPLIANT", "random-bucket-123456789012")
+        assert_successful_evaluation(self, response[0], resp_expected)
+
+    def test_non_compliant_periodic_change(self):
+        invoking_event = self.invoking_event_bucket_periodic_change
+        lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
+        s3_mock([],[{"Name": "random-bucket-123456789012"}])
+        response = RULE.lambda_handler(lambda_event, {})
+        resp_expected = build_expected_response(
+            "NON_COMPLIANT",
+            "random-bucket-123456789012",
+            annotation='The "random-bucket-123456789012" bucket is not logging to cbs-satellite-account-bucket123456789012',
+        )
+        assert_successful_evaluation(self, response[0], resp_expected)
+
+    def test_compliant_periodic_change(self):
+        invoking_event = self.invoking_event_bucket_periodic_change
+        lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
+        s3_mock("cbs-satellite-account-bucket123456789012", [{"Name": "random-bucket-123456789012"}])
+        response = RULE.lambda_handler(lambda_event, {})
+        resp_expected = build_expected_response("COMPLIANT", "random-bucket-123456789012")
+        assert_successful_evaluation(self, response[0], resp_expected)
+
+    def test_non_applicable_config_change(self):
+        invoking_event = self.invoking_event_bucket_config_change
+        lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
+        s3_mock("cbs-satellite-account-bucket123456789012", [{"Name": "cbs-satellite-account-bucket123456789012"}])
+        response = RULE.lambda_handler(lambda_event, {})
+        resp_expected = build_expected_response("NOT_APPLICABLE", "cbs-satellite-account-bucket123456789012")
+        assert_successful_evaluation(self, response[0], resp_expected)
+
+
+# Helper Functions
+
+
+def build_lambda_event(invoking_event, rule_parameters=None):
+    event_to_return = {
+        "configRuleName": "myrule",
+        "executionRoleArn": "roleArn",
+        "invokingEvent": invoking_event,
+        "accountId": "123456789012",
+        "configRuleArn": "arn:aws:config:ca-central-1:123456789012:config-rule/config-rule-8fngan",
+        "resultToken": "token",
+    }
+    if rule_parameters:
+        event_to_return["ruleParameters"] = rule_parameters
+    return event_to_return
+
+
+def build_expected_response(
+    compliance_type,
+    compliance_resource_id,
+    compliance_resource_type=DEFAULT_RESOURCE_TYPE,
+    annotation=None,
+):
+    response = {
+        "ComplianceType": compliance_type,
+        "ComplianceResourceId": compliance_resource_id,
+        "ComplianceResourceType": compliance_resource_type,
+    }
+    if annotation:
+        response["Annotation"] = annotation
+
+    return response
+
+
+def assert_successful_evaluation(test_class, response, resp_expected):
+    test_class.assertEqual(
+        resp_expected["ComplianceResourceType"], response["ComplianceResourceType"]
+    )
+    test_class.assertEqual(
+        resp_expected["ComplianceResourceId"], response["ComplianceResourceId"]
+    )
+    test_class.assertEqual(resp_expected["ComplianceType"], response["ComplianceType"])
+    test_class.assertTrue(response["OrderingTimestamp"])
+
+    if "Annotation" in resp_expected or "Annotation" in response:
+        test_class.assertEqual(resp_expected["Annotation"], response["Annotation"])
+
+
+def s3_mock(target_bucket, buckets):
+    list_buckets = {"Buckets": buckets}
+    get_bucket_logging = {
+        "LoggingEnabled": {"TargetBucket": target_bucket, "TargetPrefix": ""}
+    }
+    S3_CLIENT_MOCK.reset_mock(return_value=True)
+    S3_CLIENT_MOCK.get_bucket_logging = MagicMock(return_value=get_bucket_logging)
+    S3_CLIENT_MOCK.list_buckets = MagicMock(return_value=list_buckets)

--- a/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule_test.py
+++ b/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule_test.py
@@ -38,14 +38,13 @@ class ComplianceTest(unittest.TestCase):
     invoking_event_bucket_periodic_change = '{"awsAccountId":"123456789012","notificationCreationTime":"2016-07-13T21:50:00.373Z","messageType":"ScheduledNotification","recordVersion":"1.0"}'
     rule_parameters = '{"targetBucket":"cbs-satellite-account-bucket123456789012"}'
 
-
     def setUp(self):
         pass
 
     def test_non_compliant_config_change(self):
         invoking_event = self.invoking_event_bucket_config_change
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
-        s3_mock([],[{"Name": "random-bucket-123456789012"}])
+        s3_mock([], [{"Name": "random-bucket-123456789012"}])
         response = RULE.lambda_handler(lambda_event, {})
         resp_expected = build_expected_response(
             "NON_COMPLIANT",
@@ -57,15 +56,20 @@ class ComplianceTest(unittest.TestCase):
     def test_compliant_config_change(self):
         invoking_event = self.invoking_event_bucket_config_change
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
-        s3_mock("cbs-satellite-account-bucket123456789012", [{"Name": "random-bucket-123456789012"}])
+        s3_mock(
+            "cbs-satellite-account-bucket123456789012",
+            [{"Name": "random-bucket-123456789012"}],
+        )
         response = RULE.lambda_handler(lambda_event, {})
-        resp_expected = build_expected_response("COMPLIANT", "random-bucket-123456789012")
+        resp_expected = build_expected_response(
+            "COMPLIANT", "random-bucket-123456789012"
+        )
         assert_successful_evaluation(self, response[0], resp_expected)
 
     def test_non_compliant_periodic_change(self):
         invoking_event = self.invoking_event_bucket_periodic_change
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
-        s3_mock([],[{"Name": "random-bucket-123456789012"}])
+        s3_mock([], [{"Name": "random-bucket-123456789012"}])
         response = RULE.lambda_handler(lambda_event, {})
         resp_expected = build_expected_response(
             "NON_COMPLIANT",
@@ -77,17 +81,27 @@ class ComplianceTest(unittest.TestCase):
     def test_compliant_periodic_change(self):
         invoking_event = self.invoking_event_bucket_periodic_change
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
-        s3_mock("cbs-satellite-account-bucket123456789012", [{"Name": "random-bucket-123456789012"}])
+        s3_mock(
+            "cbs-satellite-account-bucket123456789012",
+            [{"Name": "random-bucket-123456789012"}],
+        )
         response = RULE.lambda_handler(lambda_event, {})
-        resp_expected = build_expected_response("COMPLIANT", "random-bucket-123456789012")
+        resp_expected = build_expected_response(
+            "COMPLIANT", "random-bucket-123456789012"
+        )
         assert_successful_evaluation(self, response[0], resp_expected)
 
     def test_non_applicable_config_change(self):
         invoking_event = self.invoking_event_bucket_config_change
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
-        s3_mock("cbs-satellite-account-bucket123456789012", [{"Name": "cbs-satellite-account-bucket123456789012"}])
+        s3_mock(
+            "cbs-satellite-account-bucket123456789012",
+            [{"Name": "cbs-satellite-account-bucket123456789012"}],
+        )
         response = RULE.lambda_handler(lambda_event, {})
-        resp_expected = build_expected_response("NOT_APPLICABLE", "cbs-satellite-account-bucket123456789012")
+        resp_expected = build_expected_response(
+            "NOT_APPLICABLE", "cbs-satellite-account-bucket123456789012"
+        )
         assert_successful_evaluation(self, response[0], resp_expected)
 
 

--- a/terragrunt/aws/config/s3_access_logs.tf
+++ b/terragrunt/aws/config/s3_access_logs.tf
@@ -4,8 +4,13 @@ resource "aws_config_config_rule" "cbs_s3_bucket_logging_enabled" {
   input_parameters = jsonencode({ "targetBucket" = var.satellite_bucket_name })
 
   source {
-    owner             = "AWS"
-    source_identifier = "S3_BUCKET_LOGGING_ENABLED"
+    owner             = "CUSTOM_LAMBDA"
+    source_identifier = aws_lambda_function.cbs_s3_access_logs_rule.arn
+
+    source_detail {
+      message_type                = "ScheduledNotification"
+      maximum_execution_frequency = var.config_max_execution_frequency
+    }
   }
   scope {
     compliance_resource_types = ["AWS::S3::Bucket"]
@@ -53,5 +58,96 @@ resource "aws_config_remediation_configuration" "cbs_s3_bucket_logging_enabled" 
       concurrent_execution_rate_percentage = 25
       error_percentage                     = 20
     }
+  }
+}
+
+#
+# Lambda function used by the ConfigRule
+#
+data "archive_file" "cbs_s3_access_logs_rule" {
+  type        = "zip"
+  source_file = "config_rules/s3_access_logs/s3_access_logs_rule.py"
+  output_path = "/tmp/cbs_s3_access_logs_rule.zip"
+}
+
+resource "aws_lambda_function" "cbs_s3_access_logs_rule" {
+  filename      = "/tmp/cbs_s3_access_logs_rule.zip"
+  function_name = "CbsS3AccessLogsRule"
+  role          = aws_iam_role.cbs_s3_access_logs_rule.arn
+  handler       = "s3_access_logs_rule.lambda_handler"
+
+  source_code_hash = data.archive_file.cbs_s3_access_logs_rule.output_base64sha256
+  runtime          = "python3.9"
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_lambda_permission" "cbs_s3_access_logs_rule" {
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.cbs_s3_access_logs_rule.arn
+  principal     = "config.amazonaws.com"
+  statement_id  = "AllowExecutionFromConfig"
+}
+
+resource "aws_cloudwatch_log_group" "cbs_s3_access_logs_rule" {
+  name              = "/aws/lambda/${aws_lambda_function.cbs_s3_access_logs_rule.function_name}"
+  retention_in_days = 14
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+#
+# Lambda execution role
+#
+resource "aws_iam_role" "cbs_s3_access_logs_rule" {
+  name               = "CbsS3AccessLogsRule"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume.json
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "cbs_s3_access_logs_rule_basic_execution" {
+  role       = aws_iam_role.cbs_s3_access_logs_rule.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy_attachment" "cbs_s3_access_logs_rule_policy" {
+  role       = aws_iam_role.cbs_s3_access_logs_rule.name
+  policy_arn = aws_iam_policy.policy.arn
+}
+
+resource "aws_iam_policy" "policy" {
+  name        = "CbsS3AccessLogsPolicy"
+  path        = "/"
+  description = "IAM policy for listing all S3 buckets and their logging configuration"
+  policy      = data.aws_iam_policy_document.policy.json
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = true
+  }
+}
+
+data "aws_iam_policy_document" "policy" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "s3:GetReplicationConfiguration",
+      "s3:ListAllMyBuckets"
+    ]
+    resources = ["*"]
   }
 }


### PR DESCRIPTION
Switching back to the custom lambda approach since the AWS provided S3 access logs config rule doesn't support the ability to exclude certain resources.