### PR TITLE
fix: provide bucket name as resource id

### DIFF
--- a/terragrunt/aws/config/config_rules/s3_satellite_bucket/compliance/s3_satellite_bucket_rule.py
+++ b/terragrunt/aws/config/config_rules/s3_satellite_bucket/compliance/s3_satellite_bucket_rule.py
@@ -3,6 +3,8 @@ import botocore
 import datetime
 import json
 
+from copy import copy
+
 # Set to True to get the lambda to assume the Role attached on the Config Service (cross-account).
 ASSUME_ROLE_MODE = False
 DEFAULT_RESOURCE_TYPE = "AWS::S3::Bucket"
@@ -159,11 +161,14 @@ def evaluate_compliance(configuration_item, event):
     rule_parameters = json.loads(event["ruleParameters"])
     bucket_name = rule_parameters["satelliteBucket"]
 
+    current_item = copy(configuration_item)
+    current_item["resourceId"] = bucket_name
+
     if any(b["Name"] == bucket_name for b in response["Buckets"]):
-        return build_evaluation(configuration_item, "COMPLIANT")
+        return build_evaluation(current_item, "COMPLIANT")
     else:
         return build_evaluation(
-            configuration_item,
+            current_item,
             "NON_COMPLIANT",
             f'The "{bucket_name}" bucket does not exist',
         )

--- a/terragrunt/aws/config/config_rules/s3_satellite_bucket/compliance/s3_satellite_bucket_rule_test.py
+++ b/terragrunt/aws/config/config_rules/s3_satellite_bucket/compliance/s3_satellite_bucket_rule_test.py
@@ -48,7 +48,7 @@ class ComplianceTest(unittest.TestCase):
         response = RULE.lambda_handler(lambda_event, {})
         resp_expected = build_expected_response(
             "NON_COMPLIANT",
-            "s3-ca-central-1",
+            "cbs-central-satellite-123456789012",
             annotation='The "cbs-central-satellite-123456789012" bucket does not exist',
         )
         assert_successful_evaluation(self, response, resp_expected)
@@ -58,7 +58,7 @@ class ComplianceTest(unittest.TestCase):
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
         s3_mock([{"Name": "cbs-central-satellite-123456789012"}])
         response = RULE.lambda_handler(lambda_event, {})
-        resp_expected = build_expected_response("COMPLIANT", "s3-ca-central-1")
+        resp_expected = build_expected_response("COMPLIANT", "cbs-central-satellite-123456789012")
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_non_compliant_periodic_change(self):
@@ -68,7 +68,7 @@ class ComplianceTest(unittest.TestCase):
         response = RULE.lambda_handler(lambda_event, {})
         resp_expected = build_expected_response(
             "NON_COMPLIANT",
-            "123456789012",
+            "cbs-central-satellite-123456789012",
             annotation='The "cbs-central-satellite-123456789012" bucket does not exist',
         )
         assert_successful_evaluation(self, response, resp_expected)
@@ -78,7 +78,7 @@ class ComplianceTest(unittest.TestCase):
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
         s3_mock([{"Name": "cbs-central-satellite-123456789012"}])
         response = RULE.lambda_handler(lambda_event, {})
-        resp_expected = build_expected_response("COMPLIANT", "123456789012")
+        resp_expected = build_expected_response("COMPLIANT", "cbs-central-satellite-123456789012")
         assert_successful_evaluation(self, response, resp_expected)
 
 

--- a/terragrunt/aws/config/config_rules/s3_satellite_bucket/compliance/s3_satellite_bucket_rule_test.py
+++ b/terragrunt/aws/config/config_rules/s3_satellite_bucket/compliance/s3_satellite_bucket_rule_test.py
@@ -58,7 +58,9 @@ class ComplianceTest(unittest.TestCase):
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
         s3_mock([{"Name": "cbs-central-satellite-123456789012"}])
         response = RULE.lambda_handler(lambda_event, {})
-        resp_expected = build_expected_response("COMPLIANT", "cbs-central-satellite-123456789012")
+        resp_expected = build_expected_response(
+            "COMPLIANT", "cbs-central-satellite-123456789012"
+        )
         assert_successful_evaluation(self, response, resp_expected)
 
     def test_non_compliant_periodic_change(self):
@@ -78,7 +80,9 @@ class ComplianceTest(unittest.TestCase):
         lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
         s3_mock([{"Name": "cbs-central-satellite-123456789012"}])
         response = RULE.lambda_handler(lambda_event, {})
-        resp_expected = build_expected_response("COMPLIANT", "cbs-central-satellite-123456789012")
+        resp_expected = build_expected_response(
+            "COMPLIANT", "cbs-central-satellite-123456789012"
+        )
         assert_successful_evaluation(self, response, resp_expected)
 
 


### PR DESCRIPTION
Not providing the bucket name results in a `resource is unknown or has not been discovered` error. This will fix this situation when the rule is compliant. However when its not compliant this message will still be visible since the bucket doesn't exist. This is expected behaviour.

![image](https://user-images.githubusercontent.com/85885638/151218919-f3d057e5-795a-4ff1-af06-cb464f03f0d1.png)
