### PR TITLE
fix: satellite S3 access log bucket should not log

### DIFF
--- a/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule.py
+++ b/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule.py
@@ -167,7 +167,10 @@ def evaluate_compliance(configuration_item, event):
         current_item = copy(configuration_item)
         current_item["resourceId"] = bucket["Name"]
 
-        if bucket["Name"] == logging_bucket_name:
+        if (
+            bucket["Name"] == logging_bucket_name
+            or bucket["Name"] == f"{logging_bucket_name}-access"
+        ):
             evaluations.append(build_evaluation(current_item, "NOT_APPLICABLE"))
             continue
 

--- a/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule_test.py
+++ b/terragrunt/aws/config/config_rules/s3_access_logs/s3_access_logs_rule_test.py
@@ -104,6 +104,19 @@ class ComplianceTest(unittest.TestCase):
         )
         assert_successful_evaluation(self, response[0], resp_expected)
 
+    def test_non_applicable_access_bucket_config_change(self):
+        invoking_event = self.invoking_event_bucket_config_change
+        lambda_event = build_lambda_event(invoking_event, self.rule_parameters)
+        s3_mock(
+            "",
+            [{"Name": "cbs-satellite-account-bucket123456789012-access"}],
+        )
+        response = RULE.lambda_handler(lambda_event, {})
+        resp_expected = build_expected_response(
+            "NOT_APPLICABLE", "cbs-satellite-account-bucket123456789012-access"
+        )
+        assert_successful_evaluation(self, response[0], resp_expected)
+
 
 # Helper Functions
 


### PR DESCRIPTION
# Summary
Omit the `cbs-satellite-$ACCOUNT_ID-access` bucket from the
ConfigRule check.

# Related
* Closes #45 