### PR TITLE
chore: remove autoremediate

### DIFF
--- a/terragrunt/aws/config/s3_access_logs.tf
+++ b/terragrunt/aws/config/s3_access_logs.tf
@@ -17,50 +17,6 @@ resource "aws_config_config_rule" "cbs_s3_bucket_logging_enabled" {
   }
 }
 
-resource "aws_config_remediation_configuration" "cbs_s3_bucket_logging_enabled" {
-  config_rule_name = aws_config_config_rule.cbs_s3_bucket_logging_enabled.name
-  resource_type    = "AWS::S3::Bucket"
-  target_type      = "SSM_DOCUMENT"
-  target_id        = "AWS-ConfigureS3BucketLogging"
-  target_version   = "1"
-
-  parameter {
-    name         = "AutomationAssumeRole"
-    static_value = aws_iam_role.security_config.arn
-  }
-  parameter {
-    name           = "BucketName"
-    resource_value = "RESOURCE_ID"
-  }
-  parameter {
-    name         = "TargetBucket"
-    static_value = var.satellite_bucket_name
-  }
-  parameter {
-    name         = "GrantedPermission"
-    static_value = "FULL_CONTROL"
-  }
-  parameter {
-    name         = "GranteeType"
-    static_value = "Group"
-  }
-  parameter {
-    name         = "GranteeUri"
-    static_value = "http://acs.amazonaws.com/groups/s3/LogDelivery"
-  }
-
-  automatic                  = true
-  maximum_automatic_attempts = 10
-  retry_attempt_seconds      = 3600
-
-  execution_controls {
-    ssm_controls {
-      concurrent_execution_rate_percentage = 25
-      error_percentage                     = 20
-    }
-  }
-}
-
 #
 # Lambda function used by the ConfigRule
 #

--- a/terragrunt/aws/config/wafv2_logs.tf
+++ b/terragrunt/aws/config/wafv2_logs.tf
@@ -118,7 +118,6 @@ data "aws_iam_policy_document" "wafv2_list_web_acls" {
       "wafv2:GetLoggingConfiguration",
       "wafv2:ListWebACLs",
       "wafv2:ListLoggingConfigurations",
-      "wafv2:PutLoggingConfiguration",
       "config:PutEvaluations",
       "iam:CreateServiceLinkedRole",
     ]


### PR DESCRIPTION
No longer using config to remediate violations. This will be managed by terraform and flagged via a slack message