### PR TITLE
docs: adjustments to README

### DIFF
--- a/bootstrap/central_account_iam/bootstrap.sh
+++ b/bootstrap/central_account_iam/bootstrap.sh
@@ -9,6 +9,8 @@ IFS=$'\n\t'
 #
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+ACCOUNT_ID="$(aws sts get-caller-identity | jq -r .Account)"
+echo -e "\n\033[0;33m⚡\033[0m Bootstrap central \033[0;35m$ACCOUNT_ID\033[0m\n"
 
 rm -rf "$SCRIPT_DIR"/terraform* "$SCRIPT_DIR"/.terraform*
 terraform -chdir="$SCRIPT_DIR" init

--- a/bootstrap/satellite_account_iam/bootstrap.sh
+++ b/bootstrap/satellite_account_iam/bootstrap.sh
@@ -9,6 +9,8 @@ IFS=$'\n\t'
 #
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+ACCOUNT_ID="$(aws sts get-caller-identity | jq -r .Account)"
+echo -e "\n\033[0;33m⚡\033[0m Bootstrap satellite \033[0;35m$ACCOUNT_ID\033[0m\n"
 
 rm -rf "$SCRIPT_DIR"/terraform* "$SCRIPT_DIR"/.terraform*
 terraform -chdir="$SCRIPT_DIR" init


### PR DESCRIPTION
# Summary
Reworked section on ConfigRules, removed auto-remediation debugging and moved log archive bucket structure to the bottom ([updated README](https://github.com/cds-snc/cloud-based-sensor/blob/docs/readme-cleanup/README.md)).

Also adds the AWS account ID to the bootstrap script output:  

![image](https://user-images.githubusercontent.com/2110107/151368409-ef3de0b9-6f02-457c-a1b4-4cbe0b582443.png)

