### PR TITLE
feat: restrict assumerole satellite access to a specific role

### DIFF
--- a/.github/workflows/terragrunt-apply-satellite.yml
+++ b/.github/workflows/terragrunt-apply-satellite.yml
@@ -95,7 +95,9 @@ jobs:
           aws-region: 'ca-central-1'
 
       - name: Set the Terragrunt IAM role
-        run: echo "TERRAGRUNT_IAM_ROLE=arn:aws:iam::${{ matrix.account }}:role/ConfigTerraformAdminExecutionRole" >> $GITHUB_ENV
+        run: |
+          echo "TERRAGRUNT_IAM_ROLE=arn:aws:iam::${{ matrix.account }}:role/ConfigTerraformAdminExecutionRole" >> $GITHUB_ENV
+          echo "TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME=CBSGitHubActions" >> $GITHUB_ENV
 
       - name: Terragrunt apply satellite bucket
         if: ${{ steps.filter.outputs.satellite_bucket == 'true' || steps.filter.outputs.common == 'true' }}

--- a/.github/workflows/terragrunt-plan-satellite.yml
+++ b/.github/workflows/terragrunt-plan-satellite.yml
@@ -93,7 +93,9 @@ jobs:
           aws-region: 'ca-central-1'
 
       - name: Set the Terragrunt IAM role
-        run: echo "TERRAGRUNT_IAM_ROLE=arn:aws:iam::${{ matrix.account }}:role/ConfigTerraformAdminExecutionRole" >> $GITHUB_ENV
+        run: |
+          echo "TERRAGRUNT_IAM_ROLE=arn:aws:iam::${{ matrix.account }}:role/ConfigTerraformAdminExecutionRole" >> $GITHUB_ENV
+          echo "TERRAGRUNT_IAM_ASSUME_ROLE_SESSION_NAME=CBSGitHubActions" >> $GITHUB_ENV
 
       - name: Terragrunt plan satellite bucket
         if: ${{ steps.filter.outputs.satellite_bucket == 'true' || steps.filter.outputs.common == 'true' }}

--- a/bootstrap/satellite_account_iam/main.tf
+++ b/bootstrap/satellite_account_iam/main.tf
@@ -23,7 +23,15 @@ data "aws_iam_policy_document" "config_execution_role" {
 
     principals {
       type        = "AWS"
-      identifiers = ["${var.central_account_id}"]
+      identifiers = ["arn:aws:iam::${var.central_account_id}:role/ConfigTerraformAdministratorRole"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "sts:RoleSessionName"
+      values = [
+        "CBSGitHubActions",
+      ]
     }
   }
 }


### PR DESCRIPTION
Currently any user from the central account can assume the satellite cbs admin execution role. This will PR will reduce the scope to only allow the `ConfigTerraformAdministratorRole` role as well as the `CBSGitHubActions` role session