### PR TITLE
fix: update the assume role session name

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -42,7 +42,7 @@ jobs:
           export $(printf "AWS_ACCESS_KEY_ID=%s AWS_SECRET_ACCESS_KEY=%s AWS_SESSION_TOKEN=%s" \
             $(aws sts assume-role \
               --role-arn arn:aws:iam::${{ matrix.account }}:role/ConfigTerraformAdminExecutionRole \
-              --role-session-name SatelliteAccountSession \
+              --role-session-name CBSGitHubActions \
               --duration-seconds 900 \
               --query "Credentials.[AccessKeyId,SecretAccessKey,SessionToken]" \
               --output text))


### PR DESCRIPTION
# Summary
With the IAM policies being tightened down in #70, the session
name needs to be updated to allow the central account to
continue to assume satellite account roles.