### PR TITLE
fix: quotes are not required when processing in terraform

### DIFF
--- a/terragrunt/aws/central_account/main.tf
+++ b/terragrunt/aws/central_account/main.tf
@@ -16,7 +16,7 @@ module "gh_oidc_roles" {
       claim     = "*"
     }
   ]
-  assume_policy     = data.aws_iam_policy_document.service_principal.json
+  assume_policy     = sensitive(data.aws_iam_policy_document.service_principal.json)
   billing_tag_value = var.billing_tag_value
 }
 

--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -45,7 +45,7 @@ module "log_archive_access_bucket" {
 #
 resource "aws_s3_bucket_policy" "log_archive_bucket" {
   bucket = module.log_archive_bucket.s3_bucket_id
-  policy = data.aws_iam_policy_document.log_archive_bucket.json
+  policy = sensitive(data.aws_iam_policy_document.log_archive_bucket.json)
 }
 
 data "aws_iam_policy_document" "log_archive_bucket" {

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -12,7 +12,7 @@ inputs = {
   region                             = "ca-central-1"
   satellite_bucket_name              = "cbs-satellite-${get_aws_account_id()}"
   satellite_s3_replicate_role_name   = "CbsSatelliteReplicateToLogArchive"
-  satellite_account_ids              = split("\n", chomp(file("../../satellite_accounts")))
+  satellite_account_ids              = split("\n", chomp(replace(file("../../satellite_accounts"),"\"","")))
 }
 
 remote_state {


### PR DESCRIPTION
Tweak how the account number file is processed by Terragrunt. The quotes are necessary to generate the Github action workflow matrix, however that is causing terraform to escape the quotes when used within a formatted string.