### PR TITLE
chore: migrate to a new CBS central account

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Configure AWS credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::339850311124:role/ConfigTerraformAdministratorRole
+          role-to-assume: arn:aws:iam::871282759583:role/ConfigTerraformAdministratorRole
           role-session-name: CBSGitHubActions
           aws-region: ${{ env.AWS_REGION }}
           role-duration-seconds: 900

--- a/.github/workflows/terragrunt-apply-central.yml
+++ b/.github/workflows/terragrunt-apply-central.yml
@@ -76,7 +76,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::339850311124:role/ConfigTerraformAdministratorRole
+          role-to-assume: arn:aws:iam::871282759583:role/ConfigTerraformAdministratorRole
           role-session-name: CBSGitHubActions
           aws-region: 'ca-central-1'
 

--- a/.github/workflows/terragrunt-apply-satellite.yml
+++ b/.github/workflows/terragrunt-apply-satellite.yml
@@ -91,7 +91,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::339850311124:role/ConfigTerraformAdministratorRole
+          role-to-assume: arn:aws:iam::871282759583:role/ConfigTerraformAdministratorRole
           role-session-name: CBSGitHubActions
           aws-region: 'ca-central-1'
 

--- a/.github/workflows/terragrunt-plan-central.yml
+++ b/.github/workflows/terragrunt-plan-central.yml
@@ -74,7 +74,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::339850311124:role/ConfigTerraformAdministratorRole
+          role-to-assume: arn:aws:iam::871282759583:role/ConfigTerraformAdministratorRole
           role-session-name: CBSGitHubActions
           aws-region: 'ca-central-1'
 

--- a/.github/workflows/terragrunt-plan-satellite.yml
+++ b/.github/workflows/terragrunt-plan-satellite.yml
@@ -89,7 +89,7 @@ jobs:
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@master
         with:
-          role-to-assume: arn:aws:iam::339850311124:role/ConfigTerraformAdministratorRole
+          role-to-assume: arn:aws:iam::871282759583:role/ConfigTerraformAdministratorRole
           role-session-name: CBSGitHubActions
           aws-region: 'ca-central-1'
 

--- a/bootstrap/satellite_account_iam/variables.tf
+++ b/bootstrap/satellite_account_iam/variables.tf
@@ -1,7 +1,7 @@
 variable "central_account_id" {
   description = "(Required) The account ID to centrally manage all accounts."
   type        = string
-  default     = "339850311124"
+  default     = "871282759583"
 }
 
 variable "region" {

--- a/terragrunt/env/satellite/satellite_bucket/terragrunt.hcl
+++ b/terragrunt/env/satellite/satellite_bucket/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 inputs = {
-  log_archive_kms_key_arn = "arn:aws:kms:ca-central-1:339850311124:key/02bf26d4-b787-485e-91de-c36e5f0fcd91"
+  log_archive_kms_key_arn = "arn:aws:kms:ca-central-1:871282759583:key/c4591f87-9445-4840-acb6-a5569e703c93"
 }
 
 include {

--- a/terragrunt/env/terragrunt.hcl
+++ b/terragrunt/env/terragrunt.hcl
@@ -1,6 +1,6 @@
 locals {
   vars                   = read_terragrunt_config("../env_vars.hcl")
-  log_archive_account_id = "339850311124"
+  log_archive_account_id = "871282759583"
 }
 
 inputs = {


### PR DESCRIPTION
# Summary
This will prevent us from conflicting with the existing CbsCentral
auto-remediation rules.