### PR TITLE
fix: set S3 logging buckets to correct module

### DIFF
--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -33,7 +33,7 @@ module "log_archive_bucket" {
 }
 
 module "log_archive_access_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v1.0.4//S3"
+  source            = "github.com/cds-snc/terraform-modules?ref=v1.0.4//S3_log_bucket"
   bucket_name       = "${var.log_archive_bucket_name}-access"
   billing_tag_value = var.billing_tag_value
   force_destroy     = true

--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -52,7 +52,7 @@ module "satellite_bucket" {
 }
 
 module "satellite_access_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v1.0.4//S3"
+  source            = "github.com/cds-snc/terraform-modules?ref=v1.0.4//S3_log_bucket"
   bucket_name       = "${var.satellite_bucket_name}-access"
   billing_tag_value = var.billing_tag_value
   force_destroy     = true


### PR DESCRIPTION
# Summary
Update the two S3 access log buckets to use the correct module.
This will grant them the expected `log-delivery-write` ACL.

# Related
* #76 