### PR TITLE
fix: refactor satellite bucket policy

### DIFF
--- a/terragrunt/aws/cloudtrail/cloudtrail.tf
+++ b/terragrunt/aws/cloudtrail/cloudtrail.tf
@@ -1,9 +1,3 @@
-locals {
-  satellite_bucket_arn = "arn:aws:s3:::${var.satellite_bucket_name}"
-  trail_prefix         = "cloudtrail_logs"
-  trail_arn            = "arn:aws:cloudtrail:${var.region}:${var.account_id}:trail/CbsSatelliteTrail"
-}
-
 #
 # CloudTrail: deliver all events from all regions
 # to the S3 satellite bucket
@@ -11,62 +5,12 @@ locals {
 resource "aws_cloudtrail" "satellite_trail" {
   name                          = "CbsSatelliteTrail"
   s3_bucket_name                = var.satellite_bucket_name
-  s3_key_prefix                 = local.trail_prefix
+  s3_key_prefix                 = "cloudtrail_logs"
   include_global_service_events = true
   is_multi_region_trail         = true
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
-  }
-
-  depends_on = [
-    aws_s3_bucket_policy.satellite_trail
-  ]
-}
-
-#
-# Bucket policy allowing CloudTrail to write logs
-# to the satellite bucket
-#
-resource "aws_s3_bucket_policy" "satellite_trail" {
-  bucket = var.satellite_bucket_name
-  policy = data.aws_iam_policy_document.satellite_trail.json
-}
-
-data "aws_iam_policy_document" "satellite_trail" {
-  statement {
-    principals {
-      type        = "Service"
-      identifiers = ["cloudtrail.amazonaws.com"]
-    }
-    actions = [
-      "s3:GetBucketAcl"
-    ]
-    resources = [
-      local.satellite_bucket_arn
-    ]
-  }
-  statement {
-    principals {
-      type        = "Service"
-      identifiers = ["cloudtrail.amazonaws.com"]
-    }
-    actions = [
-      "s3:PutObject"
-    ]
-    resources = [
-      "${local.satellite_bucket_arn}/${local.trail_prefix}/AWSLogs/${var.account_id}/*"
-    ]
-    condition {
-      test     = "StringEquals"
-      variable = "s3:x-amz-acl"
-      values   = ["bucket-owner-full-control"]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "aws:SourceArn"
-      values   = [local.trail_arn]
-    }
   }
 }

--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -193,7 +193,7 @@ data "aws_iam_policy_document" "load_balancer_write_logs" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = data.aws_elb_service_account.main.arn
+      identifiers = [data.aws_elb_service_account.main.arn]
     }
     actions = [
       "s3:PutObject",

--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -65,3 +65,167 @@ resource "aws_s3_bucket_ownership_controls" "satellite_bucket" {
     object_ownership = "ObjectWriter"
   }
 }
+
+#
+# Bucket policy allowing AWS services to write
+# to the satellite bucket
+#
+resource "aws_s3_bucket_policy" "satellite_bucket" {
+  bucket = module.satellite_bucket.s3_bucket_id
+  policy = data.aws_iam_policy_document.combined.json
+}
+
+data "aws_iam_policy_document" "combined" {
+  source_policy_documents = [
+    data.aws_iam_policy_document.cloudtrail_write_logs.json,
+    data.aws_iam_policy_document.log_delivery_write_logs.json,
+    data.aws_iam_policy_document.load_balancer_write_logs.json,
+    data.aws_iam_policy_document.deny_insecure_transport.json
+  ]
+}
+
+data "aws_iam_policy_document" "cloudtrail_write_logs" {
+
+  statement {
+    sid    = "CloudTrailGetAcl"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions = [
+      "s3:GetBucketAcl"
+    ]
+    resources = [
+      module.satellite_bucket.s3_bucket_arn
+    ]
+  }
+
+  statement {
+    sid    = "CloudTrailPutObject"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["cloudtrail.amazonaws.com"]
+    }
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = [
+      "${module.satellite_bucket.s3_bucket_arn}/cloudtrail_logs/AWSLogs/${var.account_id}/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:cloudtrail:${var.region}:${var.account_id}:trail/CbsSatelliteTrail"]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "log_delivery_write_logs" {
+
+  statement {
+    sid    = "LogDeliveryGetAcl"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    actions = [
+      "s3:GetBucketAcl"
+    ]
+    resources = [
+      module.satellite_bucket.s3_bucket_arn
+    ]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:${var.region}:${var.account_id}:*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.account_id]
+    }
+  }
+
+  statement {
+    sid    = "LogDeliveryPutObject"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["delivery.logs.amazonaws.com"]
+    }
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = [
+      "${module.satellite_bucket.s3_bucket_arn}/AWSLogs/${var.account_id}/*"
+    ]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = ["arn:aws:logs:${var.region}:${var.account_id}:*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [var.account_id]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "s3:x-amz-acl"
+      values   = ["bucket-owner-full-control"]
+    }
+  }
+}
+
+data "aws_elb_service_account" "main" {}
+data "aws_iam_policy_document" "load_balancer_write_logs" {
+
+  statement {
+    sid    = "ELBLogDeliveryPutObject"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = data.aws_elb_service_account.main.arn
+    }
+    actions = [
+      "s3:PutObject",
+    ]
+    resources = [
+      "${module.satellite_bucket.s3_bucket_arn}/*",
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "deny_insecure_transport" {
+
+  statement {
+    sid    = "denyInsecureTransport"
+    effect = "Deny"
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+    actions = [
+      "s3:*",
+    ]
+    resources = [
+      module.satellite_bucket.s3_bucket_arn,
+      "${module.satellite_bucket.s3_bucket_arn}/*",
+    ]
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Summary
The satellite bucket policy will also require policy items for
log delivery from other AWS services.  To reflect this change, the
policy definition is being moved out of the CloudTrail module into
the `satellite_bucket` module.

# ⚠️  Note
The `satellite_bucket` Terraform state was updated locally to remove the policy with:
```sh
cd ./terragrunt/env/satellite/cloudtrail
terragrunt state rm aws_s3_bucket_policy.satellite_trail
```


