### PR TITLE
chore: add S3 access log IAM policy

### DIFF
--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -80,7 +80,8 @@ data "aws_iam_policy_document" "combined" {
     data.aws_iam_policy_document.cloudtrail_write_logs.json,
     data.aws_iam_policy_document.log_delivery_write_logs.json,
     data.aws_iam_policy_document.load_balancer_write_logs.json,
-    data.aws_iam_policy_document.deny_insecure_transport.json
+    data.aws_iam_policy_document.deny_insecure_transport.json,
+    data.aws_iam_policy_document.allow_s3_access_logging.json
   ]
 }
 
@@ -165,7 +166,7 @@ data "aws_iam_policy_document" "log_delivery_write_logs" {
       "s3:PutObject"
     ]
     resources = [
-      "${module.satellite_bucket.s3_bucket_arn}/AWSLogs/${var.account_id}/*"
+      "${module.satellite_bucket.s3_bucket_arn}/vpc_flow_logs/AWSLogs/${var.account_id}/*"
     ]
     condition {
       test     = "ArnLike"
@@ -227,5 +228,24 @@ data "aws_iam_policy_document" "deny_insecure_transport" {
         "false"
       ]
     }
+  }
+}
+
+data "aws_iam_policy_document" "allow_s3_access_logging" {
+
+  statement {
+    sid    = "S3AccessLogging"
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl"
+    ]
+    resources = [
+      "${module.satellite_bucket.s3_bucket_arn}/s3_access_logs/*"
+    ]
   }
 }


### PR DESCRIPTION
# Summary
This allows the satellite bucket to be used as the target
for another S3 bucket's access logging.

# Related
* Closes #83 