### PR TITLE
feat: add put-bucket-logging script

### DIFF
--- a/bootstrap/central_account_iam/bootstrap.sh
+++ b/bootstrap/central_account_iam/bootstrap.sh
@@ -3,9 +3,13 @@ set -euo pipefail
 IFS=$'\n\t'
 
 #
+# PURPOSE:
 # Bootstraps a given satellite account's IAM roles.
 # This is based on the AWS access key and secret that
 # is currently exported. 
+#
+# USE:
+# ./bootstrap.sh 
 #
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"

--- a/bootstrap/satellite_account_iam/bootstrap.sh
+++ b/bootstrap/satellite_account_iam/bootstrap.sh
@@ -3,9 +3,13 @@ set -euo pipefail
 IFS=$'\n\t'
 
 #
+# PURPOSE:
 # Bootstraps a given satellite account's IAM roles.
 # This is based on the AWS access key and secret that
-# is currently exported. 
+# is currently exported.
+#
+# USE:
+# ./bootstrap.sh 
 #
 
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"

--- a/bootstrap/scripts/put-bucket-logging.sh
+++ b/bootstrap/scripts/put-bucket-logging.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+#
+# PURPOSE:
+# Sets the given target bucket(s) to use the satellite bucket 
+# in the account as the access log destination.
+#
+# USE:
+# ./put-bucket-logging.sh 'bucket-name-1 bucket-name-2 bucket-name-3'
+#
+
+set -euo pipefail
+IFS=$' '
+
+BUCKET_NAMES="$1"
+ACCOUNT_ID="$(aws sts get-caller-identity | jq -r .Account)"
+SATELLITE_BUCKET_NAME="cbs-satellite-${ACCOUNT_ID}"
+LOG_PREFIX="s3_access_logs"
+
+echo -e "\n🪣  S3 access logging for \033[0;35m${ACCOUNT_ID}\033[0m\n"
+
+for BUCKET in ${BUCKET_NAMES}; do
+    echo -e "Bucket \033[0;33m${BUCKET}\033[0m"
+    aws s3api put-bucket-logging \
+        --bucket "${BUCKET}" \
+        --bucket-logging-status '{"LoggingEnabled":{"TargetBucket":"'"${SATELLITE_BUCKET_NAME}"'","TargetPrefix":"'"${LOG_PREFIX}"'/"}}'    
+done


### PR DESCRIPTION
# Summary
Script that can be used to set S3 buckets in an account to
use the satellite bucket as the access log destination.

This fixes compliance of the `cbs_s3_bucket_logging_enabled`
ConfigRule.