### PR TITLE
feat: enable compliance check workflow

### DIFF
--- a/.github/workflows/compliance-check.yml
+++ b/.github/workflows/compliance-check.yml
@@ -2,6 +2,8 @@ name: "Compliance check"
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: "0 13 * * *" # Every day at 1pm UTC
 
 env:
   AWS_REGION: ca-central-1
@@ -57,5 +59,5 @@ jobs:
       - name: Post non-compliant slack message
         if: steps.compliance.outputs.rules != '[]'
         run: |
-          json='{"text": ":red: `${{ matrix.account }}` ConfigRules are not compliant"}'
+          json='{"text": ":red: `${{ matrix.account }}` has resources that are not compliant"}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ env.SLACK_WEBHOOK }}


### PR DESCRIPTION
# Summary
This will post into the #cloud-based-sensor channel if
any accounts have resources that are marked as
`NON_COMPLIANT` by the conformance pack.