### PR TITLE
fix: update the log archive file structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,25 +41,33 @@ terragrunt import \
 # Log archive structure
 ```
 cbs-log-archive-bucket/
-├─ [aws_account_id]/
-│  ├─ [cloudtrail_logs]/
-│  │  ├─ [trail_name]/
-│  │  │  ├─ file_1
+├─ [cloudtrail_logs]/
+│  ├─ [AWSLogs]/
+│  │  ├─ [aws_account_id]
+│  │  │  ├─ file
 │  │  │  ├─ ...
-│  ├─ [elb_logs]/
-│  │  ├─ [elb_name]/
-│  │  │  ├─ file_1
+│  │  │  
+├─ [elb_logs]/
+│  ├─ [AWSLogs]/
+│  │  ├─ [aws_account_id]
+│  │  │  ├─ file
 │  │  │  ├─ ...
-│  ├─ [s3_access_logs]/
-│  │  ├─ [bucket_name]/
-│  │  │  ├─ file_1
+│  │  │  
+├─ [s3_access_logs]/
+│  ├─ [AWSLogs]/
+│  │  ├─ [aws_account_id]
+│  │  │  ├─ file
 │  │  │  ├─ ...
-│  ├─ [vpc_flow_logs]/
-│  │  ├─ [vpc_id]/
-│  │  │  ├─ file_1
+│  │  │  
+├─ [vpc_flow_logs]/
+│  ├─ [AWSLogs]/
+│  │  ├─ [aws_account_id]
+│  │  │  ├─ file
 │  │  │  ├─ ...
-│  ├─ [waf_acl_logs]/
-│  │  ├─ [account_id]/
-│  │  │  ├─ file_1
+│  │  │  
+├─ [waf_acl_logs]/
+│  ├─ [AWSLogs]/
+│  │  ├─ [aws_account_id]
+│  │  │  ├─ file
 │  │  │  ├─ ...
 ```

--- a/bootstrap/scripts/put-bucket-logging.sh
+++ b/bootstrap/scripts/put-bucket-logging.sh
@@ -15,7 +15,7 @@ IFS=$' '
 BUCKET_NAMES="$1"
 ACCOUNT_ID="$(aws sts get-caller-identity | jq -r .Account)"
 SATELLITE_BUCKET_NAME="cbs-satellite-${ACCOUNT_ID}"
-LOG_PREFIX="s3_access_logs"
+LOG_PREFIX="s3_access_logs/AWSLogs/${ACCOUNT_ID}"
 
 echo -e "\n🪣  S3 access logging for \033[0;35m${ACCOUNT_ID}\033[0m\n"
 


### PR DESCRIPTION
# Summary 
This updated file structure for the log archive bucket is based
on the structure that AWS services provide their logs.

The new structure will be:
```
cbs-log-archive-bucket/
├─ [cloudtrail_logs]/
│  ├─ [AWSLogs]/
│  │  ├─ [aws_account_id]
│  │  │  ├─ file
│  │  │  ├─ ...
│  │  │  
├─ [elb_logs]/
│  ├─ [AWSLogs]/
│  │  ├─ [aws_account_id]
│  │  │  ├─ file
│  │  │  ├─ ...
│  │  │  
├─ [s3_access_logs]/
│  ├─ [AWSLogs]/
│  │  ├─ [aws_account_id]
│  │  │  ├─ file
│  │  │  ├─ ...
│  │  │  
├─ [vpc_flow_logs]/
│  ├─ [AWSLogs]/
│  │  ├─ [aws_account_id]
│  │  │  ├─ file
│  │  │  ├─ ...
│  │  │  
├─ [waf_acl_logs]/
│  ├─ [AWSLogs]/
│  │  ├─ [aws_account_id]
│  │  │  ├─ file
│  │  │  ├─ ...
```

# ⚠️  Note
In order to use this style the following will need to be updated in the satellite accounts:
* S3 access log prefix (`./put-bucket-logging.sh` has been updated to reflect this); and
* WAF ACL log prefix
