### PR TITLE
docs: update readme and load balancer rule description

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ cbs-log-archive-bucket/
 │  │  │  ├─ file
 │  │  │  ├─ ...
 │  │  │  
-├─ [elb_logs]/
+├─ [lb_logs]/
 │  ├─ [AWSLogs]/
 │  │  ├─ [aws_account_id]
 │  │  │  ├─ file

--- a/terragrunt/env/satellite/config/conformance_packs/cloud_based_sensor.yml
+++ b/terragrunt/env/satellite/config/conformance_packs/cloud_based_sensor.yml
@@ -26,7 +26,7 @@ Resources:
   ElbLoggingEnabled:
     Properties:
       ConfigRuleName: cbs_elb_logging_enabled
-      Description: Checks that the CBS satellite bucket exists in the account.
+      Description: A Config rule that checks whether load balancer logging is enabled
       Scope:
         ComplianceResourceTypes:
           - AWS::ElasticLoadBalancing::LoadBalancer


### PR DESCRIPTION
Updates the readme to reference the updated load balancer s3 logging path, as well as corrects the description for the load balancer config rule.