### PR TITLE
feat: add log archive event notification

### DIFF
--- a/terragrunt/aws/central_account/inputs.tf
+++ b/terragrunt/aws/central_account/inputs.tf
@@ -3,3 +3,8 @@ variable "cbs_principal_arn" {
   type        = string
   sensitive   = true
 }
+
+variable "cbs_transport_lambda_name" {
+  description = "Name of the CBS transport Lambda function"
+  type        = string
+}

--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -88,9 +88,10 @@ data "aws_lambda_function" "cbs_transport_lambda" {
 }
 
 resource "aws_s3_bucket_notification" "cbs_transport_lambda" {
-  bucket = aws_s3_bucket.log_archive_bucket.id
+  bucket = module.log_archive_bucket.s3_bucket_id
 
   lambda_function {
+    id                  = "CbsEvent"
     lambda_function_arn = data.aws_lambda_function.cbs_transport_lambda.arn
     events              = ["s3:ObjectCreated:*"]
   }

--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -79,3 +79,19 @@ data "aws_iam_policy_document" "log_archive_bucket" {
     ]
   }
 }
+
+#
+# Notify the CBS transport Lambda when a new object is created
+#
+data "aws_lambda_function" "cbs_transport_lambda" {
+  function_name = var.cbs_transport_lambda_name
+}
+
+resource "aws_s3_bucket_notification" "cbs_transport_lambda" {
+  bucket = aws_s3_bucket.log_archive_bucket.id
+
+  lambda_function {
+    lambda_function_arn = data.aws_lambda_function.cbs_transport_lambda.arn
+    events              = ["s3:ObjectCreated:*"]
+  }
+}

--- a/terragrunt/env/central/central_account/terragrunt.hcl
+++ b/terragrunt/env/central/central_account/terragrunt.hcl
@@ -2,6 +2,10 @@ terraform {
   source = "../../../aws//central_account"
 }
 
+inputs = {
+  cbs_transport_lambda_name = "CbsTransportLambda"
+}
+
 include {
   path = find_in_parent_folders()
   expose = true


### PR DESCRIPTION
# Summary
Add a notification to invoke the CBS transport lambda when
a new object is created in the log archive bucket.

# ⚠️  Note
The existing notification was imported locally, so there should be no planned changes.