### PR TITLE
fix: path to the Terraform in the checkov action

### DIFF
--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Checkov security scan
         uses: bridgecrewio/checkov-action@8d1675bd19257514c72879a34c5dfe108d0d3028 # latest as of Jan 19, 2022
         with:
-          directory: aws
+          directory: terragrunt/aws
           framework: terraform
           output_format: cli
           soft_fail: false

--- a/terragrunt/aws/.checkov.yml
+++ b/terragrunt/aws/.checkov.yml
@@ -1,8 +1,11 @@
 # Config for checkov Terraform static analysis
 
 skip-check:
+  - CKV_AWS_35  # CloudTrail default service key encryption is acceptable
+  - CKV_AWS_36  # CloudTrail log validation not required
   - CKV_AWS_115 # Lambda function-level concurrent execution limit not required
   - CKV_AWS_116 # Lambda dead-letter queue not required
   - CKV_AWS_117 # Lambda configured within a VPC not required
   - CKV_AWS_145 # S3 default service key encryption is acceptable
   - CKV_AWS_158 # CloudWatch default service key encryption is acceptable
+  - CKV2_AWS_10 # CloudTrail integration with CloudWatch not required

--- a/terragrunt/aws/config/wafv2_logs.tf
+++ b/terragrunt/aws/config/wafv2_logs.tf
@@ -79,6 +79,7 @@ resource "aws_iam_policy" "wafv2_list_web_acls" {
 }
 
 data "aws_iam_policy_document" "wafv2_list_web_acls" {
+  # checkov:skip=CKV_AWS_109: TODO tighten down resource access
   statement {
     effect = "Allow"
     actions = [


### PR DESCRIPTION
# Summary
Fix the Terraform security scan GitHub workflow's path to the
Terraform files.  Also adds suppression comments for checks
we're not concerned with.