### PR TITLE
feat: increase log retention to 90 days

### DIFF
--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -26,7 +26,7 @@ module "log_archive_bucket" {
       id      = "delete-old-objects"
       enabled = true
       expiration = {
-        days = 14
+        days = 90
       }
     }
   ]

--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -19,7 +19,7 @@ module "satellite_bucket" {
       id      = "delete-old-objects"
       enabled = true
       expiration = {
-        days = 14
+        days = 90
       }
     }
   ]


### PR DESCRIPTION
# Summary
This increases the log retention to 90 days in the satellite and
central log archive buckets, based on a recommendation from
CCCS.