### PR TITLE
feat: add CloudTrail to central account

### DIFF
--- a/.github/workflows/terragrunt-apply-central.yml
+++ b/.github/workflows/terragrunt-apply-central.yml
@@ -9,6 +9,7 @@ on:
       - ".github/workflows/terragrunt-apply-central.yml"
       - "satellite_accounts"
       - "terragrunt/aws/central_account/**"
+      - "terragrunt/aws/cloudtrail/**"
       - "terragrunt/env/central/**"
       - "terragrunt/env/common/**"
       - "terragrunt/env/terragrunt.hcl"
@@ -18,7 +19,7 @@ env:
   CONFTEST_VERSION: 0.27.0
   TERRAFORM_VERSION: 1.1.4
   TERRAGRUNT_VERSION: 0.36.0
-  TF_VAR_cbs_principal_arn: ${{ secrets.CBS_PRINCIPAL_ARN }} 
+  TF_VAR_cbs_principal_arn: ${{ secrets.CBS_PRINCIPAL_ARN }}
   TF_INPUT: false
 
 permissions:
@@ -66,10 +67,13 @@ jobs:
           filters: |
             central_account:
               - 'terragrunt/aws/central_account/**'
-              - 'terragrunt/env/central/central_account/**'    
+              - 'terragrunt/env/central/central_account/**'
+            cloudtrail:
+              - 'terragrunt/aws/cloudtrail/**'
+              - 'terragrunt/env/central/cloudtrail/**'
             common:
               - '.github/workflows/terragrunt-apply-central.yml'
-              - 'satellite_accounts'              
+              - 'satellite_accounts'
               - 'terragrunt/env/common/**'
               - 'terragrunt/env/terragrunt.hcl'
 
@@ -83,4 +87,9 @@ jobs:
       - name: Terragrunt apply central account
         if: ${{ steps.filter.outputs.central_account == 'true' || steps.filter.outputs.common == 'true' }}
         working-directory: "terragrunt/env/central/central_account"
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Terragrunt apply cloudtrail
+        if: ${{ steps.filter.outputs.cloudtrail == 'true' || steps.filter.outputs.common == 'true' }}
+        working-directory: "terragrunt/env/central/cloudtrail"
         run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/terragrunt-plan-central.yml
+++ b/.github/workflows/terragrunt-plan-central.yml
@@ -5,8 +5,9 @@ on:
   pull_request:
     paths:
       - ".github/workflows/terragrunt-plan-central.yml"
-      - "satellite_accounts"    
+      - "satellite_accounts"
       - "terragrunt/aws/central_account/**"
+      - "terragrunt/aws/cloudtrail/**"
       - "terragrunt/env/central/**"
       - "terragrunt/env/common/**"
       - "terragrunt/env/terragrunt.hcl"
@@ -64,10 +65,13 @@ jobs:
           filters: |
             central_account:
               - 'terragrunt/aws/central_account/**'
-              - 'terragrunt/env/central/central_account/**'    
+              - 'terragrunt/env/central/central_account/**'
+            cloudtrail:
+              - 'terragrunt/aws/cloudtrail/**'
+              - 'terragrunt/env/central/cloudtrail/**'
             common:
               - '.github/workflows/terragrunt-plan-central.yml'
-              - 'satellite_accounts'               
+              - 'satellite_accounts'
               - 'terragrunt/env/common/**'
               - 'terragrunt/env/terragrunt.hcl'
 
@@ -87,3 +91,13 @@ jobs:
           comment-title: "Central account"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           terragrunt: "true"
+
+      - name: Terragrunt plan cloudtrail
+        if: ${{ steps.filter.outputs.cloudtrail == 'true' || steps.filter.outputs.common == 'true' }}
+        uses: cds-snc/terraform-plan@v2
+        with:
+          directory: "terragrunt/env/central/cloudtrail"
+          comment-delete: "true"
+          comment-title: "Central CloudTrail"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          terragrunt: "true"          

--- a/terragrunt/aws/cloudtrail/cloudtrail.tf
+++ b/terragrunt/aws/cloudtrail/cloudtrail.tf
@@ -4,7 +4,7 @@
 #
 resource "aws_cloudtrail" "satellite_trail" {
   name                          = "CbsSatelliteTrail"
-  s3_bucket_name                = var.satellite_bucket_name
+  s3_bucket_name                = var.cloudtrail_bucket_name
   s3_key_prefix                 = "cloudtrail_logs"
   include_global_service_events = true
   is_multi_region_trail         = true

--- a/terragrunt/aws/cloudtrail/inputs.tf
+++ b/terragrunt/aws/cloudtrail/inputs.tf
@@ -1,0 +1,4 @@
+variable "cloudtrail_bucket_name" {
+  description = "Name of the S3 bucket that CloudTrail will send logs to"
+  type        = string
+}

--- a/terragrunt/env/central/cloudtrail/terragrunt.hcl
+++ b/terragrunt/env/central/cloudtrail/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 inputs = {
-  cloudtrail_bucket_name = include.inputs.satellite_bucket_name
+  cloudtrail_bucket_name = include.inputs.log_archive_bucket_name
 }
 
 include {


### PR DESCRIPTION
# Summary
This will send CloudTrail logs directly to the log-archive bucket and be
used to watch for anomalies in the account.

# Related
* #116