### PR TITLE
feat: set satellite bucket object expire to 14 days

### DIFF
--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -2,7 +2,7 @@
 # Satellite bucket and access logging
 #
 module "satellite_bucket" {
-  source            = "github.com/cds-snc/terraform-modules?ref=v1.0.4//S3"
+  source            = "github.com/cds-snc/terraform-modules?ref=v1.0.8//S3"
   bucket_name       = var.satellite_bucket_name
   billing_tag_value = var.billing_tag_value
 
@@ -19,7 +19,7 @@ module "satellite_bucket" {
       id      = "delete-old-objects"
       enabled = true
       expiration = {
-        days = 90
+        days = 14
       }
     }
   ]


### PR DESCRIPTION
# Summary
Update the S3 module version so that it is possible to control if
delete markers are replicated to the destination bucket.

By doing this, and not enabling delete marker replication, it means
a shorter object expiration of 14 days can be set on the satellite
bucket objects which will save storage costs.

The central log archive bucket will keep its 90 day object expire
lifecycle rule so we'll still have the logs if needed.

# ⚠️  Note
The unrelated changes to `136676205420` are from the CBS
auto-remediation rules which were disabled yesterday.

# Related
* cds-snc/terraform-modules#110