### PR TITLE
chore: pin AWS provider to 3.x

### DIFF
--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
 provider "aws" {
   region = var.region
 }


### PR DESCRIPTION
# Summary
The 4.x release of the provider contains breaking changes.