### PR TITLE
fix: billing alarm resource names to skip AWS nuke

### DIFF
--- a/terragrunt/aws/alarms/billing_alarm.tf
+++ b/terragrunt/aws/alarms/billing_alarm.tf
@@ -2,7 +2,7 @@
 resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
   provider = aws.us-east-1
 
-  alarm_name          = "BillingChangeOverThreshold"
+  alarm_name          = "CbsBillingChangeOverThreshold"
   comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = "1"
   threshold_metric_id = "anomaly"

--- a/terragrunt/aws/alarms/kms.tf
+++ b/terragrunt/aws/alarms/kms.tf
@@ -11,6 +11,7 @@ resource "aws_kms_key" "sns_cloudwatch_us_east" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
     Terraform             = true
+    Product               = "cloud-based-sensor"
   }
 }
 

--- a/terragrunt/aws/alarms/sns.tf
+++ b/terragrunt/aws/alarms/sns.tf
@@ -4,7 +4,7 @@
 resource "aws_sns_topic" "cloudwatch_alarm_us_east" {
   provider = aws.us-east-1
 
-  name              = "cloudwatch_alarm_cbs"
+  name              = "cbs-cloudwatch-alarm"
   kms_master_key_id = aws_kms_key.sns_cloudwatch_us_east.id
 
   tags = {
@@ -24,7 +24,7 @@ resource "aws_sns_topic_subscription" "cloudwatch_alarm_us_east" {
 module "notify_slack" {
   source = "github.com/cds-snc/terraform-modules?ref=v1.0.10//notify_slack"
 
-  function_name     = "notify_slack_cbs"
+  function_name     = "cbs-notify-slack"
   project_name      = var.account_id
   slack_webhook_url = var.slack_webhook_url
   sns_topic_arns    = [aws_sns_topic.cloudwatch_alarm_us_east.arn]


### PR DESCRIPTION
# Summary
Update the billing alarm resources to use the expected name
prefixes so they are not removed by the scratch account weekly
AWS nuke job.