### PR TITLE
remove ok_action from billing alarm

### DIFF
--- a/terragrunt/aws/alarms/billing_alarm.tf
+++ b/terragrunt/aws/alarms/billing_alarm.tf
@@ -9,7 +9,6 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
   alarm_description   = "Estimated billing anomaly"
   treat_missing_data  = "notBreaching"
   alarm_actions       = [aws_sns_topic.cloudwatch_alarm_us_east.arn]
-  ok_actions          = [aws_sns_topic.cloudwatch_alarm_us_east.arn]
 
   metric_query {
     id          = "anomaly"


### PR DESCRIPTION
Simple one line removal to quiet down the OK alarms telling us "IT'S OK NOW EVERYTHING IS OK."