### PR TITLE
chore: update variable description

### DIFF
--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -1,5 +1,5 @@
 variable "slack_webhook_url" {
-  description = "Slack webhook used by the Notify Slack Lambda function."
+  description = "Slack webhook used by the Notify Slack Lambda function when an alarm triggers."
   type        = string
   sensitive   = true
 }


### PR DESCRIPTION
# Summary
The Slack webhook has been updated, so changing an `alarm` module variable description to trigger a Terraform plan/apply. 