### PR TITLE
Added threshold to alert on both upper and lower boundary anomalies

### DIFF
--- a/terragrunt/aws/alarms/billing_alarm.tf
+++ b/terragrunt/aws/alarms/billing_alarm.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
   provider = aws.us-east-1
 
   alarm_name          = "CbsBillingChangeOverThreshold"
-  comparison_operator = "GreaterThanUpperThreshold"
+  comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
   evaluation_periods  = "1"
   threshold_metric_id = "anomaly"
   alarm_description   = "Estimated billing anomaly"


### PR DESCRIPTION
1 line fix to adjust anomaly detection to alert not just higher costs, but to anomalous costs lower than expected as well. (PS the algo does in fact adjust for seasonality and usage, just as an added bonus.)