### PR TITLE
fix: allow writing logs to other paths in log bucket

### DIFF
--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -165,7 +165,7 @@ data "aws_iam_policy_document" "log_delivery_write_logs" {
       "s3:PutObject"
     ]
     resources = [
-      "${module.satellite_bucket.s3_bucket_arn}/vpc_flow_logs/AWSLogs/${var.account_id}/*"
+      "${module.satellite_bucket.s3_bucket_arn}/*/AWSLogs/${var.account_id}/*"
     ]
     condition {
       test     = "ArnLike"


### PR DESCRIPTION
Ran into an error with the load balancer log not having permission to write to the logging bucket. Tracked it down to the IAM permission that was too specific and only allowed writing to the vpc_flow_logs directory.

![image](https://user-images.githubusercontent.com/85885638/165636573-d019eaa2-cb3b-4cb8-bf19-1c5a8b1fdfa4.png)
