### PR TITLE
Updating anomaly values to smooth out model

### DIFF
--- a/terragrunt/aws/alarms/billing_alarm.tf
+++ b/terragrunt/aws/alarms/billing_alarm.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
 
   metric_query {
     id          = "anomaly"
-    expression  = "ANOMALY_DETECTION_BAND(current)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 3)"
     label       = "Billing (Expected)"
     return_data = "true"
   }
@@ -26,7 +26,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
       metric_name = "EstimatedCharges"
       namespace   = "AWS/Billing"
       period      = "21600"
-      stat        = "Maximum"
+      stat        = "Average"
       dimensions = {
         Currency = "USD"
       }

--- a/terragrunt/aws/alarms/billing_alarm.tf
+++ b/terragrunt/aws/alarms/billing_alarm.tf
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
 
   metric_query {
     id          = "anomaly"
-    expression  = "ANOMALY_DETECTION_BAND(m1, 3)"
+    expression  = "ANOMALY_DETECTION_BAND(current, 3)"
     label       = "Billing (Expected)"
     return_data = "true"
   }


### PR DESCRIPTION
Switching the statistic used to build the model to `average` value vs `maximum` (recommended for values that may not be flat), and increasing the standard deviation band from $2USD to $3USD.

