### PR TITLE
Update billing alarm

### DIFF
--- a/terragrunt/aws/alarms/billing_alarm.tf
+++ b/terragrunt/aws/alarms/billing_alarm.tf
@@ -3,7 +3,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
   provider = aws.us-east-1
 
   alarm_name          = "CbsBillingChangeOverThreshold"
-  comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
+  comparison_operator = "GreaterThanUpperThreshold"
   evaluation_periods  = "2"
   threshold_metric_id = "anomaly"
   alarm_description   = "Estimated billing anomaly"

--- a/terragrunt/aws/alarms/billing_alarm.tf
+++ b/terragrunt/aws/alarms/billing_alarm.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
 
   alarm_name          = "CbsBillingChangeOverThreshold"
   comparison_operator = "LessThanLowerOrGreaterThanUpperThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
   threshold_metric_id = "anomaly"
   alarm_description   = "Estimated billing anomaly"
   treat_missing_data  = "notBreaching"
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
 
   metric_query {
     id          = "anomaly"
-    expression  = "ANOMALY_DETECTION_BAND(current, 3)"
+    expression  = "ANOMALY_DETECTION_BAND(current, 4)"
     label       = "Billing (Expected)"
     return_data = "true"
   }
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "billing_change_over_threshold" {
     metric {
       metric_name = "EstimatedCharges"
       namespace   = "AWS/Billing"
-      period      = "21600"
+      period      = "43200"
       stat        = "Average"
       dimensions = {
         Currency = "USD"


### PR DESCRIPTION
Changing the period to 12 hours because according to AWS:

>The ML algorithm we use currently works well with dense data that exhibit seasonality and trends. In this case, since this metric is expected to have only 1 datapoint every 12 hours, this feature may not work well for this metric...(metric being 'billing' in this case)

So in light of this increasing period to 12 hours, and number of evalution periods to compare to alarm points.
