### PR TITLE
chore: add AWS-Landing-Zone-ConfigRecorderRole

### DIFF
--- a/terragrunt/aws/config/iam.tf
+++ b/terragrunt/aws/config/iam.tf
@@ -1,3 +1,7 @@
+data "aws_iam_role" "landing_zone_config_recorder_role" {
+  name = "AWS-Landing-Zone-ConfigRecorderRole"
+}
+
 resource "aws_iam_role" "security_config" {
   name               = "CbsConfigPolicy"
   assume_role_policy = data.aws_iam_policy_document.aws_config_assume_role_policy.json
@@ -8,6 +12,7 @@ resource "aws_iam_policy_attachment" "managed_policy" {
   roles = [
     aws_iam_role.security_config.name,
     aws_iam_role.cbs_s3_satellite_bucket_rule.name,
+    data.aws_iam_role.landing_zone_config_recorder_role.name,
   ]
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWS_ConfigRole"
 }


### PR DESCRIPTION
# Summary
The Landing Zone has attached a role to our managed policy that cannot
be removed due to an org SCP.  As a result, the attachment is being
added to the Terraform to prevent future `terraform apply` failures.

# Related
* #145 