### PR TITLE
feat: add Org Cloud Trail replication role from CT

### DIFF
--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -1,6 +1,6 @@
 locals {
   calculated_replicate_role_arns = [
-    for account_id in var.satellite_account_ids : "arn:aws:iam::${account_id}:role/${var.satellite_s3_replicate_role_name}",
+    for account_id in var.satellite_account_ids : "arn:aws:iam::${account_id}:role/${var.satellite_s3_replicate_role_name}"
   ]
   trusted_replicate_role_arns = concat(
     local.calculated_replicate_role_arns,

--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -1,7 +1,11 @@
 locals {
-  trusted_replicate_role_arns = [
-    for account_id in var.satellite_account_ids : "arn:aws:iam::${account_id}:role/${var.satellite_s3_replicate_role_name}"
+  calculated_replicate_role_arns = [
+    for account_id in var.satellite_account_ids : "arn:aws:iam::${account_id}:role/${var.satellite_s3_replicate_role_name}",
   ]
+  trusted_replicate_role_arns = concat(
+    local.calculated_replicate_role_arns,
+    ["arn:aws:iam::274536870005:role/service-role/s3crr_role_for_aws-controltower-logs-274536870005-ca-central-1"]
+  )
 }
 
 #


### PR DESCRIPTION
# Summary | Résumé

Add the IAM role used in the Org Level Cloud Trail account from Control
Tower.

This work is already done on the Cloud Trail side of things, and this
just allows that to replicate to this bucket.

