### PR TITLE
fix: create SNS topic for transport lambda

### DIFF
--- a/terragrunt/aws/central_account/kms.tf
+++ b/terragrunt/aws/central_account/kms.tf
@@ -51,4 +51,49 @@ data "aws_iam_policy_document" "log_archive_encrypt" {
       identifiers = [var.core_replicate_role_arn]
     }
   }
+
+  statement {
+    sid    = "AllowSNSAccess"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+      "kms:CreateGrant",
+      "kms:ListGrants",
+      "kms:DescribeKey"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values = [
+        "sns.${var.region}.amazonaws.com"
+      ]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "kms:CallerAccount"
+      values = [
+        var.log_archive_account_id
+      ]
+    }
+  }
+
+  statement {
+    sid    = "AllowS3Access"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*"
+    ]
+    resources = ["*"]
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+  }
 }

--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -99,12 +99,8 @@ data "aws_iam_policy_document" "log_archive_bucket" {
 }
 
 #
-# Notify the CBS transport Lambda when a new object is created
+# Publish a notification to the SNS topic when objects are created
 #
-data "aws_lambda_function" "cbs_transport_lambda" {
-  function_name = var.cbs_transport_lambda_name
-}
-
 resource "aws_s3_bucket_notification" "cbs_transport_lambda" {
   bucket = module.log_archive_bucket.s3_bucket_id
 

--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -108,9 +108,9 @@ data "aws_lambda_function" "cbs_transport_lambda" {
 resource "aws_s3_bucket_notification" "cbs_transport_lambda" {
   bucket = module.log_archive_bucket.s3_bucket_id
 
-  lambda_function {
-    id                  = "CbsEvent"
-    lambda_function_arn = data.aws_lambda_function.cbs_transport_lambda.arn
-    events              = ["s3:ObjectCreated:*"]
+  topic {
+    id        = "CbsEvent"
+    topic_arn = aws_sns_topic.log_archive.arn
+    events    = ["s3:ObjectCreated:*"]
   }
 }

--- a/terragrunt/aws/central_account/sns.tf
+++ b/terragrunt/aws/central_account/sns.tf
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "log_archive_topic_policy" {
     ]
     principals {
       type        = "AWS"
-      identifiers = [var.log_archive_account_id]
+      identifiers = ["arn:aws:iam::${var.log_archive_account_id}:root"]
     }
   }
 

--- a/terragrunt/aws/central_account/sns.tf
+++ b/terragrunt/aws/central_account/sns.tf
@@ -1,0 +1,87 @@
+resource "aws_sns_topic" "log_archive" {
+  name              = "log-archive"
+  kms_master_key_id = aws_kms_key.log_archive_encrypt.id
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+}
+
+resource "aws_sns_topic_policy" "log_archive" {
+  arn    = aws_sns_topic.log_archive.arn
+  policy = data.aws_iam_policy_document.log_archive_topic_policy.json
+}
+
+data "aws_iam_policy_document" "log_archive_topic_policy" {
+  policy_id = "SNS Access Policy"
+
+  # Allow this account to use the topic
+  statement {
+    sid    = "AllowSelfAccess"
+    effect = "Allow"
+    actions = [
+      "SNS:Publish",
+      "SNS:RemovePermission",
+      "SNS:SetTopicAttributes",
+      "SNS:DeleteTopic",
+      "SNS:ListSubscriptionsByTopic",
+      "SNS:GetTopicAttributes",
+      "SNS:AddPermission",
+      "SNS:Subscribe"
+    ]
+    resources = [
+      aws_sns_topic.log_archive.arn
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = ["*"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceOwner"
+      values = [
+        var.log_archive_account_id,
+      ]
+    }
+  }
+
+  # Allow transport Lambda to consume SNS notifications
+  statement {
+    sid    = "AllowLambdaAccess"
+    effect = "Allow"
+    actions = [
+      "SNS:Subscribe",
+      "SNS:ListSubscriptionsByTopic"
+    ]
+    resources = [
+      aws_sns_topic.log_archive.arn
+    ]
+    principals {
+      type        = "AWS"
+      identifiers = [var.log_archive_account_id]
+    }
+  }
+
+  # Allow S3 log archive bucket to publish SNS notifications
+  statement {
+    sid    = "AllowS3Access"
+    effect = "Allow"
+    actions = [
+      "SNS:Publish"
+    ]
+    resources = [
+      aws_sns_topic.log_archive.arn
+    ]
+    principals {
+      type        = "Service"
+      identifiers = ["s3.amazonaws.com"]
+    }
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values = [
+        module.log_archive_bucket.s3_bucket_arn
+      ]
+    }
+  }
+}


### PR DESCRIPTION
# Summary
Add an SNS topic to the central log archive account as this is now the mechanism CBS uses to invoke the transport lambda.

# Related
- #176 