### PR TITLE
fix: add checkout to GitHub exporter workflow

### DIFF
--- a/.github/workflows/export-github-data.yml
+++ b/.github/workflows/export-github-data.yml
@@ -8,6 +8,9 @@ jobs:
   export-data:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # tag=v3.1.0
+
       - name: Export Data
         uses: cds-snc/github-repository-metadata-exporter@main
         with:


### PR DESCRIPTION
# Summary
Update GitHub exporter workflow to include checkout step.

# Related
- cds-snc/platform-core-services#204