### PR TITLE
feat: add s3 object lifecycle rule to access logs

### DIFF
--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -2,7 +2,7 @@
 # Satellite bucket and access logging
 #
 module "satellite_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v6.1.5"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v7.0.1"
   bucket_name       = var.satellite_bucket_name
   billing_tag_value = var.billing_tag_value
 
@@ -52,11 +52,21 @@ module "satellite_bucket" {
 }
 
 module "satellite_access_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v6.1.5"
+  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v7.0.1"
   bucket_name       = "${var.satellite_bucket_name}-access"
   billing_tag_value = var.billing_tag_value
   versioning_status = "Disabled"
   force_destroy     = true
+
+  lifecycle_rule = [
+    {
+      id      = "delete-old-objects"
+      enabled = true
+      expiration = {
+        days = 90
+      }
+    }
+  ]  
 }
 
 resource "aws_s3_bucket_ownership_controls" "satellite_bucket" {

--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -66,7 +66,7 @@ module "satellite_access_bucket" {
         days = 90
       }
     }
-  ]  
+  ]
 }
 
 resource "aws_s3_bucket_ownership_controls" "satellite_bucket" {


### PR DESCRIPTION
# Summary
Add a lifecycle rule to the CBS satellite access log bucket that deletes old objects after 90 days.  This will help reduce the size of these buckets while still give us time to investigate logs if needed.