### PR TITLE
chore: fix deprecated workflow set-output commands

### DIFF
--- a/.github/workflows/retrieve-accounts.yml
+++ b/.github/workflows/retrieve-accounts.yml
@@ -23,4 +23,4 @@ jobs:
         id: set-matrix
         run: |
           accounts=$(jq -n -c "{\"include\": [inputs | {"account": .} ] }"  satellite_accounts)
-          echo "::set-output name=matrix::$accounts"
+          echo "matrix=$accounts" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Summary
Update the deprecated set-output GitHub workflow commands to use the [new syntax](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter).
