### PR TITLE
fix: add target_prefix to satellite bucket access logs

### DIFF
--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -2,7 +2,7 @@
 # Satellite bucket and access logging
 #
 module "satellite_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v8.0.0"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.1.0"
   bucket_name       = var.satellite_bucket_name
   billing_tag_value = var.billing_tag_value
 
@@ -12,6 +12,7 @@ module "satellite_bucket" {
 
   logging = {
     target_bucket = module.satellite_access_bucket.s3_bucket_id
+    target_prefix = "logs/"
   }
 
   lifecycle_rule = [
@@ -52,7 +53,7 @@ module "satellite_bucket" {
 }
 
 module "satellite_access_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v8.0.0"
+  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v9.1.0"
   bucket_name       = "${var.satellite_bucket_name}-access"
   billing_tag_value = var.billing_tag_value
   versioning_status = "Disabled"

--- a/terragrunt/aws/satellite_bucket/s3.tf
+++ b/terragrunt/aws/satellite_bucket/s3.tf
@@ -2,7 +2,7 @@
 # Satellite bucket and access logging
 #
 module "satellite_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.1.0"
+  source            = "github.com/cds-snc/terraform-modules//S3?ref=v9.2.0"
   bucket_name       = var.satellite_bucket_name
   billing_tag_value = var.billing_tag_value
 
@@ -12,7 +12,6 @@ module "satellite_bucket" {
 
   logging = {
     target_bucket = module.satellite_access_bucket.s3_bucket_id
-    target_prefix = "logs/"
   }
 
   lifecycle_rule = [
@@ -53,7 +52,7 @@ module "satellite_bucket" {
 }
 
 module "satellite_access_bucket" {
-  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v9.1.0"
+  source            = "github.com/cds-snc/terraform-modules//S3_log_bucket?ref=v9.2.0"
   bucket_name       = "${var.satellite_bucket_name}-access"
   billing_tag_value = var.billing_tag_value
   versioning_status = "Disabled"


### PR DESCRIPTION
# Summary
Update the logging configuration on the satellite bucket to include a target_prefix for the access logs.

This was previously an optional parameter for the API that is now required:
https://docs.aws.amazon.com/AmazonS3/latest/API/API_LoggingEnabled.html#AmazonS3-Type-LoggingEnabled-TargetPrefix