### PR TITLE
fix: overwritten bucket policy

### DIFF
--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -96,7 +96,7 @@ data "aws_iam_policy_document" "log_archive_bucket" {
   statement {
     principals {
       type        = "AWS"
-      identifiers = [(var.cbs_principal_role_arn)]
+      identifiers = [var.cbs_principal_role_arn]
     }
     effect  = "Allow"
     actions = ["s3:GetObject"]

--- a/terragrunt/aws/central_account/s3.tf
+++ b/terragrunt/aws/central_account/s3.tf
@@ -89,22 +89,14 @@ data "aws_iam_policy_document" "log_archive_bucket" {
       module.log_archive_bucket.s3_bucket_arn
     ]
   }
-}
 
-#
-# Bucket Policy that allows the specified principal to get objects
-#
-
-resource "aws_s3_bucket_policy" "log-archive-bucket-get-objects" {
-  bucket = module.log_archive_bucket.s3_bucket_id
-  policy = data.aws_iam_policy_document.log-archive-bucket-get-objects.json
-}
-
-data "aws_iam_policy_document" "log-archive-bucket-get-objects" {
+  #
+  # Bucket Policy that allows the specified principal to get objects
+  #
   statement {
     principals {
       type        = "AWS"
-      identifiers = [sensitive(var.cbs_principal_role_arn)]
+      identifiers = [(var.cbs_principal_role_arn)]
     }
     effect  = "Allow"
     actions = ["s3:GetObject"]


### PR DESCRIPTION
# Summary | Résumé

Fixing the previous PR where the bucket policy was overwritten since it needs to be a single resource